### PR TITLE
feat: MG Module

### DIFF
--- a/Managment_Group/main.tf
+++ b/Managment_Group/main.tf
@@ -1,0 +1,4 @@
+resource "azurerm_management_group" "example_parent" {
+  display_name = var.display_name
+  parent_management_group_id = var.parent_management_group_id != null && var.parent_management_group_id != "" ? var.parent_management_group_id : null
+}

--- a/Managment_Group/variables.tf
+++ b/Managment_Group/variables.tf
@@ -1,0 +1,11 @@
+variable "display_name" {
+    description = "Name for the management group."
+    type        = string
+    default     = "ParentGroup"
+}
+
+variable "parent_management_group_id" {
+    description = "ID of the parent management group. If not provided, the group will be root."
+    type        = string
+    default     = null
+}


### PR DESCRIPTION
This pull request introduces a new Terraform resource for managing Azure Management Groups and adds the necessary variables to support flexible configuration. The most important changes are:

**Azure Management Group Resource:**

* Added a new `azurerm_management_group` resource in `main.tf` that allows creation of a management group with a configurable display name and optional parent group.

**Configuration Variables:**

* Introduced `display_name` and `parent_management_group_id` variables in `variables.tf` to enable customization of the management group name and its hierarchy placement.