### PR TITLE
feat: ACR Module Update

### DIFF
--- a/ACR/main.tf
+++ b/ACR/main.tf
@@ -23,7 +23,7 @@ module "avm-res-containerregistry-registry" {
   network_rule_set                        = var.network_rule_set
   public_network_access_enabled           = var.public_network_access_enabled
   quarantine_policy_enabled               = var.quarantine_policy_enabled
-  retention_policy_in_days                = var.retention_policy_in_days
+  retention_policy_in_days                = var.sku == "Premium" ? var.retention_policy_in_days : null
   sku                                     = var.sku
-  zone_redundancy_enabled                 = var.zone_redundancy_enabled
+  zone_redundancy_enabled                 = var.sku == "Premium" ? var.zone_redundancy_enabled : false
 }


### PR DESCRIPTION
This pull request updates the configuration for the Azure Container Registry module to ensure certain features are only enabled for the "Premium" SKU. Conditional logic has been added to prevent unsupported settings from being applied to other SKUs.

Conditional feature enablement based on SKU:

* Set `retention_policy_in_days` only if the `sku` is "Premium"; otherwise, it is set to `null`.
* Enable `zone_redundancy_enabled` only for the "Premium" SKU; otherwise, it is set to `false`.